### PR TITLE
Bump mainnet API gateway default version to 3.0.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,8 +60,8 @@ module "aws_deploy-main-eu-north-1" {
 }
 
 module "aws_gateway" {
-  source   = "github.com/aeternity/terraform-aws-api-gateway?ref=v1.0.0"
-  dns_zone = "${var.dns_zone}"
+  source    = "github.com/aeternity/terraform-aws-api-gateway?ref=v1.0.0"
+  dns_zone  = "${var.dns_zone}"
   api_dns   = "${var.domain}"
   api_alias = "${var.domain_alias}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,11 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.0.1"
+  default = "v2.2.0"
 }
 
 variable "package" {
-  default = "https://releases.ops.aeternity.com/aeternity-2.3.0-ubuntu-x86_64.tar.gz"
+  default = "https://releases.ops.aeternity.com/aeternity-3.0.1-ubuntu-x86_64.tar.gz"
 }
 
 variable "dns_zone" {


### PR DESCRIPTION
Scheduled for May 29th.